### PR TITLE
Update AgaveClient and ProjectManagement classes to allow setting config

### DIFF
--- a/agave_api/client.py
+++ b/agave_api/client.py
@@ -30,7 +30,7 @@ class AgaveClient:
 
     @property
     def project_management(self):
-        return ProjectManagement(self)
+        return ProjectManagement(self, self.account_token, self.project_id)
 
     @property
     def file_management(self):
@@ -67,6 +67,12 @@ class AgaveClient:
         return self.http_client.post(url, **kwargs)
 
     # Add other HTTP methods (put, delete, etc.) as needed
+
+    def set_account_token(self, account_token: str):
+        self.account_token = account_token
+
+    def set_project_id(self, project_id: str):
+        self.project_id = project_id
 
     def __del__(self):
         """

--- a/agave_api/project_management.py
+++ b/agave_api/project_management.py
@@ -24,8 +24,8 @@ class ProjectManagement:
         """
         self.agave_client = agave_client
         self.headers = self.agave_client.headers.copy()
-        self.account_token = None
-        self.project_id = None
+        self.account_token = account_token
+        self.project_id = project_id
         
         if account_token:
             self._set_account_token(account_token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agave_api"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Python client for the Agave API"
 authors = ["Joe Petrantoni <79169021+jpetrantoni@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/joepetrantoni/rethink/unified-project-graph/upg/sync/fetch.py", line 83, in <module>
    fetch = Fetch(
            ^^^^^^
  File "/Users/joepetrantoni/rethink/unified-project-graph/upg/sync/fetch.py", line 15, in __init__
    self.project_management = self.agave.project_management(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'ProjectManagement' object is not callable
```