### PR TITLE
chore: Update AgaveClient to include timeout parameter in constructor

### DIFF
--- a/agave_api/client.py
+++ b/agave_api/client.py
@@ -10,13 +10,14 @@ class AgaveClient:
     Base class for Agave API
     """
 
-    def __init__(self, client_id: str, client_secret: str):
+    def __init__(self, client_id: str, client_secret: str, timeout: float = 30.0):
         """
         Initializes a new instance of the AgaveClient class.
 
         Args:
             client_id (str): The client ID.
             client_secret (str): The client secret.
+            timeout (float): The timeout for HTTP requests in seconds. Defaults to 30 seconds.
         """
         self.base_url = "https://api.agaveapi.com"
         self.headers = {
@@ -26,7 +27,8 @@ class AgaveClient:
         }
         self.account_token = None
         self.project_id = None
-        self.http_client = httpx.Client()
+        self.timeout = timeout
+        self.http_client = httpx.Client(timeout=self.timeout)
 
     @property
     def project_management(self):
@@ -50,8 +52,16 @@ class AgaveClient:
 
         Returns:
             httpx.Response: The response from the server.
+
+        Raises:
+            httpx.TimeoutException: If the request times out.
         """
-        return self.http_client.get(url, **kwargs)
+        try:
+            return self.http_client.get(url, **kwargs)
+        except httpx.TimeoutException as e:
+            raise httpx.TimeoutException(
+                f"Request timed out after {self.timeout} seconds"
+            ) from e
 
     def post(self, url: str, **kwargs):
         """
@@ -63,8 +73,16 @@ class AgaveClient:
 
         Returns:
             httpx.Response: The response from the server.
+
+        Raises:
+            httpx.TimeoutException: If the request times out.
         """
-        return self.http_client.post(url, **kwargs)
+        try:
+            return self.http_client.post(url, **kwargs)
+        except httpx.TimeoutException as e:
+            raise httpx.TimeoutException(
+                f"Request timed out after {self.timeout} seconds"
+            ) from e
 
     # Add other HTTP methods (put, delete, etc.) as needed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agave_api"
-version = "0.1.3"
+version = "0.1.4"
 description = "A Python client for the Agave API"
 authors = ["Joe Petrantoni <79169021+jpetrantoni@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
Fixes
```
  File "/Users/joepetrantoni/Library/Caches/pypoetry/virtualenvs/upg-d8ZzJHJn-py3.11/lib/python3.11/site-packages/httpx/_transports/default.py", line 232, in handle_request
    with map_httpcore_exceptions():
  File "/Users/joepetrantoni/.pyenv/versions/3.11.1/lib/python3.11/contextlib.py", line 155, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/Users/joepetrantoni/Library/Caches/pypoetry/virtualenvs/upg-d8ZzJHJn-py3.11/lib/python3.11/site-packages/httpx/_transports/default.py", line 86, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ReadTimeout: The read operation timed out
```