### PR TITLE
Refactor Agave Client, Add Tests and Drawing Versions Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,7 +154,7 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-tests/
+tests/data/*
 
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can

--- a/agave_api/__init__.py
+++ b/agave_api/__init__.py
@@ -1,6 +1,47 @@
-from .client import AgaveClient
+from typing import Optional
+
+from .client import BaseAgaveClient
 from .link import Link
 from .file_management import FileManagement
 from .project_management import ProjectManagement
+
+
+class AgaveClient(BaseAgaveClient):
+    """
+    Base class for Agave API
+    """
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        account_token: Optional[str] = None,
+        project_id: Optional[str] = None,
+        timeout: Optional[float] = 30.0,
+    ):
+        """
+        Initializes a new instance of the AgaveClient class inheriting from BaseAgaveClient.
+
+        Args:
+            client_id (str): The client ID.
+            client_secret (str): The client secret.
+            account_token (str): The account token.
+            project_id (str): The project ID.
+            timeout (float): The timeout for HTTP requests in seconds. Defaults to 30 seconds.
+        """
+        super().__init__(client_id, client_secret, account_token, project_id, timeout)
+
+
+    @property
+    def project_management(self):
+        return ProjectManagement(self, self.account_token, self.project_id)
+
+    @property
+    def file_management(self):
+        return FileManagement(self)
+
+    @property
+    def link(self):
+        return Link(self)
 
 __all__ = ["AgaveClient", "Link", "FileManagement", "ProjectManagement"]

--- a/agave_api/__init__.py
+++ b/agave_api/__init__.py
@@ -31,7 +31,6 @@ class AgaveClient(BaseAgaveClient):
         """
         super().__init__(client_id, client_secret, account_token, project_id, timeout)
 
-
     @property
     def project_management(self):
         return ProjectManagement(self, self.account_token, self.project_id)
@@ -43,5 +42,6 @@ class AgaveClient(BaseAgaveClient):
     @property
     def link(self):
         return Link(self)
+
 
 __all__ = ["AgaveClient", "Link", "FileManagement", "ProjectManagement"]

--- a/agave_api/client.py
+++ b/agave_api/client.py
@@ -1,6 +1,7 @@
 import httpx
 from typing import Optional
 
+
 class BaseAgaveClient:
     """
     Base class for Agave API

--- a/agave_api/client.py
+++ b/agave_api/client.py
@@ -1,13 +1,7 @@
 import httpx
 from typing import Optional
 
-
-from .link import Link
-from .file_management import FileManagement
-from .project_management import ProjectManagement
-
-
-class AgaveClient:
+class BaseAgaveClient:
     """
     Base class for Agave API
     """
@@ -39,18 +33,6 @@ class AgaveClient:
         self.timeout = timeout
         self.http_client = httpx.Client(timeout=self.timeout)
 
-    @property
-    def project_management(self):
-        return ProjectManagement(self, self.account_token, self.project_id)
-
-    @property
-    def file_management(self):
-        return FileManagement(self)
-
-    @property
-    def link(self):
-        return Link(self)
-
     def get(self, url: str, **kwargs):
         """
         Sends a GET request using httpx.
@@ -66,11 +48,13 @@ class AgaveClient:
             httpx.TimeoutException: If the request times out.
         """
         try:
-            return self.http_client.get(url, **kwargs)
+            return self.http_client.get(url, **kwargs).json()
         except httpx.TimeoutException as e:
             raise httpx.TimeoutException(
                 f"Request timed out after {self.timeout} seconds"
             ) from e
+        except httpx.HTTPError as e:
+            raise httpx.HTTPError(f"HTTP error occurred: {e}") from e
 
     def post(self, url: str, **kwargs):
         """
@@ -87,11 +71,13 @@ class AgaveClient:
             httpx.TimeoutException: If the request times out.
         """
         try:
-            return self.http_client.post(url, **kwargs)
+            return self.http_client.post(url, **kwargs).json()
         except httpx.TimeoutException as e:
             raise httpx.TimeoutException(
                 f"Request timed out after {self.timeout} seconds"
             ) from e
+        except httpx.HTTPError as e:
+            raise httpx.HTTPError(f"HTTP error occurred: {e}") from e
 
     def __del__(self):
         """

--- a/agave_api/file_management.py
+++ b/agave_api/file_management.py
@@ -1,5 +1,7 @@
 from typing import List, Optional
 
+from .client import BaseAgaveClient
+
 
 class FileManagement:
     """
@@ -11,7 +13,7 @@ class FileManagement:
 
     def __init__(
         self,
-        agave_client,
+        agave_client: BaseAgaveClient,
     ):
         """
         Initializes a new instance of the FileManagement class.

--- a/agave_api/link.py
+++ b/agave_api/link.py
@@ -1,9 +1,12 @@
+from .client import BaseAgaveClient
+
+
 class Link:
     """
     Handles authentication-related functionalities for the Agave API.
     """
 
-    def __init__(self, agave_client):
+    def __init__(self, agave_client: BaseAgaveClient):
         self.agave_client = agave_client
 
     def create(self, reference_id: str):

--- a/agave_api/project_management.py
+++ b/agave_api/project_management.py
@@ -9,6 +9,7 @@ def ensure_account_token(func: Callable):
     def wrapper(self, *args, account_token: Optional[str] = None, **kwargs):
         self._ensure_account_token(account_token)
         return func(self, *args, **kwargs)
+
     return wrapper
 
 
@@ -18,7 +19,9 @@ def ensure_project_id(required: bool = True):
         def wrapper(self, *args, project_id: Optional[str] = None, **kwargs):
             self._ensure_project_id(project_id, required)
             return func(self, *args, project_id=project_id, **kwargs)
+
         return wrapper
+
     return decorator
 
 
@@ -68,100 +71,112 @@ class ProjectManagement:
             url += f"/{resource_id}"
         return url
 
-    def _add_pagination(self, params: Dict[str, Any], page: Optional[int], per_page: Optional[int]):
+    def _add_pagination(
+        self, params: Dict[str, Any], page: Optional[int], per_page: Optional[int]
+    ):
         if page is not None:
             params["page"] = page
         if per_page is not None:
             params["per_page"] = per_page
 
-    def _add_include_source_fields(self, params: Dict[str, Any], include_source_fields: Optional[List[str]]):
+    def _add_include_source_fields(
+        self, params: Dict[str, Any], include_source_fields: Optional[List[str]]
+    ):
         if include_source_fields:
             params["Include-Source-Data"] = ",".join(include_source_fields)
 
-    def _api_call(self, method: str, endpoint: str, resource_id: Optional[str] = None, **kwargs) -> Dict[str, Any]:
+    def _api_call(
+        self, method: str, endpoint: str, resource_id: Optional[str] = None, **kwargs
+    ) -> Dict[str, Any]:
         url = self._build_url(endpoint, resource_id)
         params = {}
-        self._add_pagination(params, kwargs.get('page'), kwargs.get('per_page'))
-        self._add_include_source_fields(params, kwargs.get('include_source_fields'))
-        
+        self._add_pagination(params, kwargs.get("page"), kwargs.get("per_page"))
+        self._add_include_source_fields(params, kwargs.get("include_source_fields"))
+
         headers = self.headers.copy()
-        if kwargs.get('account_token'):
-            headers["Account-Token"] = kwargs['account_token']
-        if kwargs.get('project_id'):
-            headers["Project-Id"] = kwargs['project_id']
+        if kwargs.get("account_token"):
+            headers["Account-Token"] = kwargs["account_token"]
+        if kwargs.get("project_id"):
+            headers["Project-Id"] = kwargs["project_id"]
 
         return getattr(self.agave_client, method)(url, params=params, headers=headers)
 
     @ensure_account_token
     @ensure_project_id(required=False)
-    def project(self, project_id: Optional[str] = None, **kwargs) -> Optional[Dict[str, Any]]:
-        return self._api_call('get', 'projects', project_id or self.project_id, **kwargs)
+    def project(
+        self, project_id: Optional[str] = None, **kwargs
+    ) -> Optional[Dict[str, Any]]:
+        return self._api_call(
+            "get", "projects", project_id or self.project_id, **kwargs
+        )
 
     @ensure_account_token
     def projects(self, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'projects', **kwargs)
+        return self._api_call("get", "projects", **kwargs)
 
     @ensure_account_token
     @ensure_project_id()
     def rfis(self, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'rfis', **kwargs)
+        return self._api_call("get", "rfis", **kwargs)
 
     @ensure_account_token
     @ensure_project_id()
     def rfi(self, rfi_id: str, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'rfis', rfi_id, **kwargs)
+        return self._api_call("get", "rfis", rfi_id, **kwargs)
 
     @ensure_account_token
     @ensure_project_id()
     def submittals(self, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'submittals', **kwargs)
+        return self._api_call("get", "submittals", **kwargs)
 
     @ensure_account_token
     @ensure_project_id()
     def submittal(self, submittal_id: str, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'submittals', submittal_id, **kwargs)
+        return self._api_call("get", "submittals", submittal_id, **kwargs)
 
     @ensure_account_token
     @ensure_project_id()
     def specifications(self, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'specification-sections', **kwargs)
+        return self._api_call("get", "specification-sections", **kwargs)
 
     @ensure_account_token
     @ensure_project_id()
     def specification(self, specification_id: str, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'specification-sections', specification_id, **kwargs)
+        return self._api_call(
+            "get", "specification-sections", specification_id, **kwargs
+        )
 
     @ensure_account_token
     @ensure_project_id(required=False)
     def contacts(self, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'contacts', **kwargs)
+        return self._api_call("get", "contacts", **kwargs)
 
     @ensure_account_token
     @ensure_project_id(required=False)
     def contact(self, contact_id: str, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'contacts', contact_id, **kwargs)
+        return self._api_call("get", "contacts", contact_id, **kwargs)
 
     @ensure_account_token
     @ensure_project_id(required=False)
     def vendors(self, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'vendors', **kwargs)
+        return self._api_call("get", "vendors", **kwargs)
 
     @ensure_account_token
     @ensure_project_id(required=False)
     def vendor(self, vendor_id: str, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'vendors', vendor_id, **kwargs)
+        return self._api_call("get", "vendors", vendor_id, **kwargs)
 
     @ensure_account_token
     @ensure_project_id()
     def drawings(self, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'drawings', **kwargs)
+        return self._api_call("get", "drawings", **kwargs)
 
     @ensure_account_token
     @ensure_project_id()
     def drawing(self, drawing_id: str, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', 'drawings', drawing_id, **kwargs)
+        return self._api_call("get", "drawings", drawing_id, **kwargs)
 
     @ensure_account_token
     @ensure_project_id()
     def drawing_versions(self, drawing_id: str, **kwargs) -> Dict[str, Any]:
-        return self._api_call('get', f'drawings/{drawing_id}/versions', **kwargs)
+        return self._api_call("get", f"drawings/{drawing_id}/versions", **kwargs)

--- a/agave_api/project_management.py
+++ b/agave_api/project_management.py
@@ -1,27 +1,34 @@
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Callable
+from functools import wraps
+
+from .client import BaseAgaveClient
+
+
+def ensure_account_token(func: Callable):
+    @wraps(func)
+    def wrapper(self, *args, account_token: Optional[str] = None, **kwargs):
+        self._ensure_account_token(account_token)
+        return func(self, *args, **kwargs)
+    return wrapper
+
+
+def ensure_project_id(required: bool = True):
+    def decorator(func: Callable):
+        @wraps(func)
+        def wrapper(self, *args, project_id: Optional[str] = None, **kwargs):
+            self._ensure_project_id(project_id, required)
+            return func(self, *args, project_id=project_id, **kwargs)
+        return wrapper
+    return decorator
 
 
 class ProjectManagement:
-    """
-    Manages projects and related resources within the Agave API.
-
-    This class provides methods to interact with various project-related endpoints
-    of the Agave API, including projects, RFIs, submittals, specifications,
-    contacts, vendors, and drawings.
-    """
-
     def __init__(
         self,
-        agave_client,
+        agave_client: BaseAgaveClient,
         account_token: Optional[str] = None,
         project_id: Optional[str] = None,
     ):
-        """
-        Initializes a new instance of the ProjectManagement class.
-
-        Args:
-            agave_client (AgaveClient): The Agave client instance for making API requests.
-        """
         self.agave_client = agave_client
         self.headers = self.agave_client.headers.copy()
         self.account_token = account_token
@@ -33,12 +40,6 @@ class ProjectManagement:
             self._set_project_id(project_id)
 
     def _ensure_account_token(self, account_token: Optional[str] = None):
-        """
-        Ensures that an account token is set.
-
-        Raises:
-            ValueError: If no account token is set.
-        """
         if self.account_token is None:
             if account_token:
                 self._set_account_token(account_token)
@@ -48,519 +49,119 @@ class ProjectManagement:
     def _ensure_project_id(
         self, project_id: Optional[str] = None, required: bool = True
     ):
-        """
-        Ensures that a project_id is set.
-
-        Raises:
-            ValueError: If no project_id is set.
-        """
         if project_id:
             self._set_project_id(project_id)
-        else:
-            if required and not self.project_id:
-                raise ValueError("Project ID is required")
-
-    def _add_include_source_fields(self, include_source_fields: Optional[List[str]]):
-        """
-        Adds the Include-Source-Data header if include_source_fields is provided.
-
-        Args:
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-        """
-        if include_source_fields:
-            self.headers["Include-Source-Data"] = ",".join(include_source_fields)
+        elif required and not self.project_id:
+            raise ValueError("Project ID is required")
 
     def _set_project_id(self, project_id: str):
-        """
-        Sets the project ID for the current instance and updates the headers.
-
-        Args:
-            project_id (str): The project ID to set.
-        """
         self.project_id = project_id
         self.headers["Project-Id"] = project_id
 
     def _set_account_token(self, account_token: str):
-        """
-        Sets the account token for the current instance and updates the headers.
-
-        Args:
-            account_token (str): The account token to set.
-        """
         self.account_token = account_token
         self.headers["Account-Token"] = account_token
 
-    def project(
-        self,
-        project_id: Optional[str] = None,
-        include_source_fields: Optional[List[str]] = None,
-        account_token: Optional[str] = None,
-    ) -> Optional[Dict[str, Any]]:
-        """
-        Fetches a project by its ID.
+    def _build_url(self, endpoint: str, resource_id: Optional[str] = None) -> str:
+        url = f"{self.agave_client.base_url}/{endpoint}"
+        if resource_id:
+            url += f"/{resource_id}"
+        return url
 
-        Args:
-            project_id (Optional[str]): The project ID. If not provided, uses the instance's project_id.
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-            account_token (Optional[str]): The account token. If not provided, uses the instance's account_token.
-
-        Returns:
-            Optional[Dict[str, Any]]: The project data as a dictionary, or None if an error occurs.
-
-        Raises:
-            ValueError: If neither project_id nor account_token is set.
-        """
-        try:
-            self._ensure_account_token(account_token)
-
-            self._ensure_project_id(project_id, required=False)
-
-            url = f"{self.agave_client.base_url}/projects/{self.project_id}"
-            self._add_include_source_fields(include_source_fields)
-            response = self.agave_client.get(url, headers=self.headers)
-            return response.json()
-        except Exception as e:
-            print(f"Error fetching project: {e}")
-            return None
-
-    def projects(
-        self,
-        include_source_fields: Optional[List[str]] = None,
-        page: Optional[int] = 1,
-        per_page: Optional[int] = 100,
-        account_token: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Fetches all projects.
-
-        Args:
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-            page (Optional[int]): The page number to fetch. Defaults to 1.
-            per_page (Optional[int]): The number of results per page. Defaults to 100.
-            account_token (Optional[str]): The account token. If not provided, uses the instance's account_token.
-
-        Returns:
-            Dict[str, Any]: A dictionary containing a list of projects and pagination metadata.
-
-        Raises:
-            ValueError: If account_token is not set.
-        """
-        self._ensure_account_token(account_token)
-
-        url = f"{self.agave_client.base_url}/projects"
-        params = {}
+    def _add_pagination(self, params: Dict[str, Any], page: Optional[int], per_page: Optional[int]):
         if page is not None:
             params["page"] = page
         if per_page is not None:
             params["per_page"] = per_page
 
-        if params:
-            query_string = "&".join(f"{k}={v}" for k, v in params.items())
-            url += f"?{query_string}"
+    def _add_include_source_fields(self, params: Dict[str, Any], include_source_fields: Optional[List[str]]):
+        if include_source_fields:
+            params["Include-Source-Data"] = ",".join(include_source_fields)
 
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def rfis(
-        self,
-        include_source_fields: Optional[List[str]] = None,
-        page: Optional[int] = 1,
-        per_page: Optional[int] = 100,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Fetches all RFIs (Requests for Information).
-
-        Args:
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-            page (Optional[int]): The page number to fetch. Defaults to 1.
-            per_page (Optional[int]): The number of results per page. Defaults to 100.
-            account_token (Optional[str]): The account token. If not provided, uses the instance's account_token.
-            project_id (Optional[str]): The project ID. If not provided, uses the instance's project_id.
-
-        Returns:
-            Dict[str, Any]: A dictionary containing a list of RFIs and pagination metadata.
-
-        Raises:
-            ValueError: If neither account_token nor project_id is set.
-        """
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id)
-
-        url = f"{self.agave_client.base_url}/rfis"
-
+    def _api_call(self, method: str, endpoint: str, resource_id: Optional[str] = None, **kwargs) -> Dict[str, Any]:
+        url = self._build_url(endpoint, resource_id)
         params = {}
-        if page is not None:
-            params["page"] = page
-        if per_page is not None:
-            params["per_page"] = per_page
-
-        if params:
-            query_string = "&".join(f"{k}={v}" for k, v in params.items())
-            url += f"?{query_string}"
-
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def rfi(
-        self,
-        rfi_id: str,
-        include_source_fields: Optional[List[str]] = None,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Fetches an RFI by its ID.
-
-        Args:
-            rfi_id (str): The ID of the RFI.
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-            account_token (Optional[str]): The account token. If not provided, uses the instance's account_token.
-            project_id (Optional[str]): The project ID. If not provided, uses the instance's project_id.
-
-        Returns:
-            Dict[str, Any]: The RFI data as a dictionary.
-
-        Raises:
-            ValueError: If neither account_token nor project_id is set.
-        """
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id)
-
-        url = f"{self.agave_client.base_url}/rfis/{rfi_id}"
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def submittals(
-        self,
-        include_source_fields: Optional[List[str]] = None,
-        page: Optional[int] = 1,
-        per_page: Optional[int] = 100,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Fetches all submittals.
-
-        Args:
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-            page (Optional[int]): The page number to fetch. Defaults to 1.
-            per_page (Optional[int]): The number of results per page. Defaults to 100.
-            account_token (Optional[str]): The account token. If not provided, uses the instance's account_token.
-            project_id (Optional[str]): The project ID. If not provided, uses the instance's project_id.
-
-        Returns:
-            Dict[str, Any]: A dictionary containing a list of submittals and pagination metadata.
-
-        Raises:
-            ValueError: If neither account_token nor project_id is set.
-        """
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id)
-
-        url = f"{self.agave_client.base_url}/submittals"
-        params = {}
-        if page is not None:
-            params["page"] = page
-        if per_page is not None:
-            params["per_page"] = per_page
-
-        if params:
-            query_string = "&".join(f"{k}={v}" for k, v in params.items())
-            url += f"?{query_string}"
-
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def submittal(
-        self,
-        submittal_id: str,
-        include_source_fields: Optional[List[str]] = None,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Fetches a submittal by its ID.
-
-        Args:
-            submittal_id (str): The ID of the submittal.
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-            account_token (Optional[str]): The account token. If not provided, uses the instance's account_token.
-            project_id (Optional[str]): The project ID. If not provided, uses the instance's project_id.
-
-        Returns:
-            Dict[str, Any]: The submittal data as a dictionary.
-
-        Raises:
-            ValueError: If neither account_token nor project_id is set.
-        """
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id)
-
-        url = f"{self.agave_client.base_url}/submittals/{submittal_id}"
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def specifications(
-        self,
-        include_source_fields: Optional[List[str]] = None,
-        page: Optional[int] = None,
-        per_page: Optional[int] = None,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Fetches all specifications.
-
-        Args:
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-            page (Optional[int]): The page number to fetch.
-            per_page (Optional[int]): The number of results per page.
-            account_token (Optional[str]): The account token. If not provided, uses the instance's account_token.
-            project_id (Optional[str]): The project ID. If not provided, uses the instance's project_id.
-
-        Returns:
-            Dict[str, Any]: A dictionary containing a list of specifications and pagination metadata.
-
-        Raises:
-            ValueError: If neither account_token nor project_id is set.
-        """
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id)
-
-        url = f"{self.agave_client.base_url}/specification-sections"
-
-        params = {}
-        if page is not None:
-            params["page"] = page
-        if per_page is not None:
-            params["per_page"] = per_page
-
-        if params:
-            query_string = "&".join(f"{k}={v}" for k, v in params.items())
-            url += f"?{query_string}"
-
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def specification(
-        self,
-        specification_id: str,
-        include_source_fields: Optional[List[str]] = None,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Fetches a specification by its ID.
-
-        Args:
-            specification_id (str): The ID of the specification.
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-            account_token (Optional[str]): The account token. If not provided, uses the instance's account_token.
-            project_id (Optional[str]): The project ID. If not provided, uses the instance's project_id.
-
-        Returns:
-            Dict[str, Any]: The specification data as a dictionary.
-
-        Raises:
-            ValueError: If neither account_token nor project_id is set.
-        """
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id)
-
-        url = f"{self.agave_client.base_url}/specification-sections/{specification_id}"
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def contacts(
-        self,
-        include_source_fields: Optional[List[str]] = None,
-        page: Optional[int] = None,
-        per_page: Optional[int] = None,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Fetches all contacts.
-
-        Args:
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-            page (Optional[int]): The page number to fetch.
-            per_page (Optional[int]): The number of results per page.
-
-        Returns:
-            dict: A dictionary containing a list of contacts and pagination metadata.
-        """
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id, required=False)
-
-        url = f"{self.agave_client.base_url}/contacts"
-        params = {}
-        if page is not None:
-            params["page"] = page
-        if per_page is not None:
-            params["per_page"] = per_page
-
-        if params:
-            query_string = "&".join(f"{k}={v}" for k, v in params.items())
-            url += f"?{query_string}"
-
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def contact(
-        self,
-        contact_id: str,
-        include_source_fields: Optional[List[str]] = None,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ):
-        """
-        Fetches a contact by its ID.
-
-        Args:
-            contact_id (str): The ID of the contact.
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-
-        Returns:
-            dict: The contact.
-        """
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id, required=False)
-
-        url = f"{self.agave_client.base_url}/contacts/{contact_id}"
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def vendors(
-        self,
-        include_source_fields: Optional[List[str]] = None,
-        page: Optional[int] = None,
-        per_page: Optional[int] = None,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ):
-        """
-        Fetches all vendors.
-
-        Args:
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-            page (Optional[int]): The page number to fetch.
-            per_page (Optional[int]): The number of results per page.
-
-        Returns:
-            dict: A dictionary containing a list of vendors.
-        """
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id, required=False)
-
-        url = f"{self.agave_client.base_url}/vendors"
-        params = {}
-        if page is not None:
-            params["page"] = page
-        if per_page is not None:
-            params["per_page"] = per_page
-
-        if params:
-            query_string = "&".join(f"{k}={v}" for k, v in params.items())
-            url += f"?{query_string}"
-
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def vendor(
-        self,
-        vendor_id: str,
-        include_source_fields: Optional[List[str]] = None,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ):
-        """
-        Fetches a vendor by its ID.
-
-        Args:
-            vendor_id (str): The ID of the vendor.
-            include_source_fields (Optional[List[str]]): A list of fields to include in the response.
-
-        Returns:
-            dict: The vendor.
-        """
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id, required=False)
-
-        url = f"{self.agave_client.base_url}/vendors/{vendor_id}"
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def drawings(
-        self,
-        include_source_fields: Optional[List[str]] = None,
-        page: Optional[int] = None,
-        per_page: Optional[int] = None,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ):
-        """
-        Fetches all drawings.
-        """
-
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id)
-
-        url = f"{self.agave_client.base_url}/drawings"
-        params = {}
-        if page is not None:
-            params["page"] = page
-        if per_page is not None:
-            params["per_page"] = per_page
-
-        if params:
-            query_string = "&".join(f"{k}={v}" for k, v in params.items())
-            url += f"?{query_string}"
-
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
-
-    def drawing(
-        self,
-        drawing_id: str,
-        include_source_fields: Optional[List[str]] = None,
-        account_token: Optional[str] = None,
-        project_id: Optional[str] = None,
-    ):
-        """
-        Fetches a drawing by its ID.
-        """
-
-        self._ensure_account_token(account_token)
-
-        self._ensure_project_id(project_id)
-
-        url = f"{self.agave_client.base_url}/drawings/{drawing_id}"
-        self._add_include_source_fields(include_source_fields)
-        response = self.agave_client.get(url, headers=self.headers)
-        return response.json()
+        self._add_pagination(params, kwargs.get('page'), kwargs.get('per_page'))
+        self._add_include_source_fields(params, kwargs.get('include_source_fields'))
+        
+        headers = self.headers.copy()
+        if kwargs.get('account_token'):
+            headers["Account-Token"] = kwargs['account_token']
+        if kwargs.get('project_id'):
+            headers["Project-Id"] = kwargs['project_id']
+
+        return getattr(self.agave_client, method)(url, params=params, headers=headers)
+
+    @ensure_account_token
+    @ensure_project_id(required=False)
+    def project(self, project_id: Optional[str] = None, **kwargs) -> Optional[Dict[str, Any]]:
+        return self._api_call('get', 'projects', project_id or self.project_id, **kwargs)
+
+    @ensure_account_token
+    def projects(self, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'projects', **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id()
+    def rfis(self, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'rfis', **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id()
+    def rfi(self, rfi_id: str, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'rfis', rfi_id, **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id()
+    def submittals(self, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'submittals', **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id()
+    def submittal(self, submittal_id: str, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'submittals', submittal_id, **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id()
+    def specifications(self, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'specification-sections', **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id()
+    def specification(self, specification_id: str, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'specification-sections', specification_id, **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id(required=False)
+    def contacts(self, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'contacts', **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id(required=False)
+    def contact(self, contact_id: str, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'contacts', contact_id, **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id(required=False)
+    def vendors(self, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'vendors', **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id(required=False)
+    def vendor(self, vendor_id: str, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'vendors', vendor_id, **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id()
+    def drawings(self, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'drawings', **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id()
+    def drawing(self, drawing_id: str, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', 'drawings', drawing_id, **kwargs)
+
+    @ensure_account_token
+    @ensure_project_id()
+    def drawing_versions(self, drawing_id: str, **kwargs) -> Dict[str, Any]:
+        return self._api_call('get', f'drawings/{drawing_id}/versions', **kwargs)

--- a/poetry.lock
+++ b/poetry.lock
@@ -115,6 +115,20 @@ files = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 description = "Sniff out which async library your code is running under"
@@ -139,4 +153,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cef7f515ce9cb29f4735c8024abe9074a8ef527febe4a33e16bb93e6b25d69e6"
+content-hash = "0eabf9a164174f03c1766423ff75ea40cecca279047c0e9df153107fb0a900c7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ python = "^3.10"
 httpx = "^0.27.0"
 
 
+[tool.poetry.group.dev.dependencies]
+python-dotenv = "^1.0.1"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "agave_api"
-version = "0.1.5"
+version = "0.1.6"
 description = "A Python client for the Agave API"
 authors = ["Joe Petrantoni <79169021+jpetrantoni@users.noreply.github.com>"]
 readme = "README.md"

--- a/tests/project_management.py
+++ b/tests/project_management.py
@@ -1,0 +1,245 @@
+import sys
+import os
+from typing import Callable
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agave_api import AgaveClient
+
+SAVE_DIR = "tests/data"
+
+
+def save_json(data, filename):
+    save_path = os.path.join(SAVE_DIR, filename)
+    os.makedirs(os.path.dirname(save_path), exist_ok=True)
+    with open(save_path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def test(
+    agave_client: AgaveClient,
+    test_name: str,
+    test_func: Callable,
+    check_func: Callable,
+    additional_args: tuple = ()
+):
+    try:
+        try:
+            response = test_func(agave_client, *additional_args)
+            save_json(response, f"{test_name}.json")
+        except Exception as e:
+            raise e
+        if not check_func(response):
+            raise Exception(f"Check failed for {test_name}")
+        print(f"\033[92m{test_name} passed\033[0m")
+        return response
+    except Exception as e:
+        raise Exception(f"\033[91m{test_name} failed: {e}\033[0m")
+
+
+def test_projects(agave_client: AgaveClient):
+    return test(
+        agave_client,
+        "projects",
+        lambda client: client.project_management.projects(),
+        lambda projects: isinstance(projects, dict) and "data" in projects,
+    )
+
+
+def test_project(agave_client: AgaveClient, project_id: str):
+    return test(
+        agave_client,
+        f"project_{project_id}",
+        lambda client: client.project_management.project(),
+        lambda project: isinstance(project, dict) and "id" in project,   
+    )
+
+
+def test_rfis(agave_client: AgaveClient):
+    return test(
+        agave_client,
+        "rfis",
+        lambda client: client.project_management.rfis(),
+        lambda rfis: isinstance(rfis, dict) and "data" in rfis,
+    )
+
+
+def test_rfi(agave_client: AgaveClient, rfi_id: str):
+    return test(
+        agave_client,
+        f"rfi_{rfi_id}",
+        lambda client, rid: client.project_management.rfi(rid),
+        lambda rfi: isinstance(rfi, dict) and "id" in rfi,
+        (rfi_id,)
+    )
+
+
+def test_submittals(agave_client: AgaveClient):
+    return test(
+        agave_client,
+        "submittals",
+        lambda client: client.project_management.submittals(),
+        lambda submittals: isinstance(submittals, dict) and "data" in submittals,
+    )
+
+
+def test_submittal(agave_client: AgaveClient, submittal_id: str):
+    return test(
+        agave_client,
+        f"submittal_{submittal_id}",
+        lambda client, sid: client.project_management.submittal(sid),
+        lambda submittal: isinstance(submittal, dict) and "id" in submittal,
+        (submittal_id,)
+    )
+
+
+def test_specifications(agave_client: AgaveClient):
+    return test(
+        agave_client,
+        "specifications",
+        lambda client: client.project_management.specifications(),
+        lambda specifications: isinstance(specifications, dict) and "data" in specifications,
+    )
+
+
+def test_specification(agave_client: AgaveClient, specification_id: str):
+    return test(
+        agave_client,
+        f"specification_{specification_id}",
+        lambda client, sid: client.project_management.specification(sid),
+        lambda specification: isinstance(specification, dict) and "id" in specification,
+        (specification_id,)
+    )
+
+
+def test_contacts(agave_client: AgaveClient):
+    return test(
+        agave_client,
+        "contacts",
+        lambda client: client.project_management.contacts(),
+        lambda contacts: isinstance(contacts, dict) and "data" in contacts,
+    )
+
+
+def test_contact(agave_client: AgaveClient, contact_id: str):
+    return test(
+        agave_client,
+        f"contact_{contact_id}",
+        lambda client, cid: client.project_management.contact(cid),
+        lambda contact: isinstance(contact, dict) and "id" in contact,
+        (contact_id,)
+    )
+
+
+def test_vendors(agave_client: AgaveClient):
+    return test(
+        agave_client,
+        "vendors",
+        lambda client: client.project_management.vendors(),
+        lambda vendors: isinstance(vendors, dict) and "data" in vendors,
+    )
+
+
+def test_vendor(agave_client: AgaveClient, vendor_id: str):
+    return test(
+        agave_client,
+        f"vendor_{vendor_id}",
+        lambda client, vid: client.project_management.vendor(vid),
+        lambda vendor: isinstance(vendor, dict) and "id" in vendor,
+        (vendor_id,)
+    )
+
+
+def test_drawings(agave_client: AgaveClient):
+    return test(
+        agave_client,
+        "drawings",
+        lambda client: client.project_management.drawings(),
+        lambda drawings: isinstance(drawings, dict) and "data" in drawings,
+    )
+
+
+def test_drawing(agave_client: AgaveClient, drawing_id: str):
+    return test(
+        agave_client,
+        f"drawing_{drawing_id}",
+        lambda client, did: client.project_management.drawing(did),
+        lambda drawing: isinstance(drawing, dict) and "id" in drawing,
+        (drawing_id,)
+    )
+
+
+def test_drawing_versions(agave_client: AgaveClient, drawing_id: str):
+    return test(
+        agave_client,
+        f"drawing_versions_{drawing_id}",
+        lambda client, did: client.project_management.drawing_versions(did),
+        lambda drawing_versions: isinstance(drawing_versions, dict) and "data" in drawing_versions,
+        (drawing_id,)
+    )
+
+
+def get_id_to_test(resource_name: str, multiple_response: dict):
+    if not isinstance(multiple_response, dict):
+        raise Exception(f"Expected a dictionary, got {type(multiple_response)}")
+    if not isinstance(multiple_response.get("data", []), list):
+        raise Exception(
+            f"Expected a list, got {type(multiple_response.get('data', []))}"
+        )
+    test_id = multiple_response.get("data", [{}])[0].get("id", None)
+    if not test_id:
+        raise Exception(f"No {resource_name} id found")
+    return test_id
+
+
+def run_tests(agave_client: AgaveClient, project_id: str):
+    projects_response = test_projects(agave_client)
+    # Use consistent project id for all tests
+    test_project(agave_client, project_id)
+
+    # Test RFIs
+    rfis_response = test_rfis(agave_client)
+    test_rfi(agave_client, get_id_to_test("rfi", rfis_response))
+
+    # Test Submittals
+    submittals_response = test_submittals(agave_client)
+    test_submittal(agave_client, get_id_to_test("submittal", submittals_response))
+
+    # Test Specifications
+    specifications_response = test_specifications(agave_client)
+    test_specification(
+        agave_client, get_id_to_test("specification", specifications_response)
+    )
+
+    # Test Contacts
+    contacts_response = test_contacts(agave_client)
+    test_contact(agave_client, get_id_to_test("contact", contacts_response))
+
+    # Test Vendors
+    vendors_response = test_vendors(agave_client)
+    test_vendor(agave_client, get_id_to_test("vendor", vendors_response))
+
+    # Test Drawings
+    drawings_response = test_drawings(agave_client)
+    drawing_id = get_id_to_test("drawing", drawings_response)
+    test_drawing(agave_client, drawing_id)
+
+    # Test Drawing Versions
+    test_drawing_versions(agave_client, drawing_id)
+
+
+if __name__ == "__main__":
+    import os
+    import json
+    from dotenv import load_dotenv
+    
+    load_dotenv()
+
+    client_id = os.getenv("CLIENT_ID")
+    client_secret = os.getenv("CLIENT_SECRET")
+    account_token = os.getenv("ACCOUNT_TOKEN")
+    project_id = os.getenv("PROJECT_ID")
+
+    agave_client = AgaveClient(client_id, client_secret, account_token, project_id)
+
+    run_tests(agave_client, project_id)

--- a/tests/project_management.py
+++ b/tests/project_management.py
@@ -1,12 +1,14 @@
-import sys
 import os
 from typing import Callable
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from pathlib import Path
 
 from agave_api import AgaveClient
 
-SAVE_DIR = "tests/data"
+# Add the parent directory to the Python path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+SAVE_DIR = Path(__file__).parent / "data"
 
 
 def save_json(data, filename):
@@ -21,7 +23,7 @@ def test(
     test_name: str,
     test_func: Callable,
     check_func: Callable,
-    additional_args: tuple = ()
+    additional_args: tuple = (),
 ):
     try:
         try:
@@ -51,7 +53,7 @@ def test_project(agave_client: AgaveClient, project_id: str):
         agave_client,
         f"project_{project_id}",
         lambda client: client.project_management.project(),
-        lambda project: isinstance(project, dict) and "id" in project,   
+        lambda project: isinstance(project, dict) and "id" in project,
     )
 
 
@@ -70,7 +72,7 @@ def test_rfi(agave_client: AgaveClient, rfi_id: str):
         f"rfi_{rfi_id}",
         lambda client, rid: client.project_management.rfi(rid),
         lambda rfi: isinstance(rfi, dict) and "id" in rfi,
-        (rfi_id,)
+        (rfi_id,),
     )
 
 
@@ -89,7 +91,7 @@ def test_submittal(agave_client: AgaveClient, submittal_id: str):
         f"submittal_{submittal_id}",
         lambda client, sid: client.project_management.submittal(sid),
         lambda submittal: isinstance(submittal, dict) and "id" in submittal,
-        (submittal_id,)
+        (submittal_id,),
     )
 
 
@@ -98,7 +100,8 @@ def test_specifications(agave_client: AgaveClient):
         agave_client,
         "specifications",
         lambda client: client.project_management.specifications(),
-        lambda specifications: isinstance(specifications, dict) and "data" in specifications,
+        lambda specifications: isinstance(specifications, dict)
+        and "data" in specifications,
     )
 
 
@@ -108,7 +111,7 @@ def test_specification(agave_client: AgaveClient, specification_id: str):
         f"specification_{specification_id}",
         lambda client, sid: client.project_management.specification(sid),
         lambda specification: isinstance(specification, dict) and "id" in specification,
-        (specification_id,)
+        (specification_id,),
     )
 
 
@@ -127,7 +130,7 @@ def test_contact(agave_client: AgaveClient, contact_id: str):
         f"contact_{contact_id}",
         lambda client, cid: client.project_management.contact(cid),
         lambda contact: isinstance(contact, dict) and "id" in contact,
-        (contact_id,)
+        (contact_id,),
     )
 
 
@@ -146,7 +149,7 @@ def test_vendor(agave_client: AgaveClient, vendor_id: str):
         f"vendor_{vendor_id}",
         lambda client, vid: client.project_management.vendor(vid),
         lambda vendor: isinstance(vendor, dict) and "id" in vendor,
-        (vendor_id,)
+        (vendor_id,),
     )
 
 
@@ -165,7 +168,7 @@ def test_drawing(agave_client: AgaveClient, drawing_id: str):
         f"drawing_{drawing_id}",
         lambda client, did: client.project_management.drawing(did),
         lambda drawing: isinstance(drawing, dict) and "id" in drawing,
-        (drawing_id,)
+        (drawing_id,),
     )
 
 
@@ -174,8 +177,9 @@ def test_drawing_versions(agave_client: AgaveClient, drawing_id: str):
         agave_client,
         f"drawing_versions_{drawing_id}",
         lambda client, did: client.project_management.drawing_versions(did),
-        lambda drawing_versions: isinstance(drawing_versions, dict) and "data" in drawing_versions,
-        (drawing_id,)
+        lambda drawing_versions: isinstance(drawing_versions, dict)
+        and "data" in drawing_versions,
+        (drawing_id,),
     )
 
 
@@ -232,7 +236,7 @@ if __name__ == "__main__":
     import os
     import json
     from dotenv import load_dotenv
-    
+
     load_dotenv()
 
     client_id = os.getenv("CLIENT_ID")


### PR DESCRIPTION
1. Restructured `AgaveClient` class:
   - Split into `BaseAgaveClient` and `AgaveClient`
   - Moved common HTTP methods to `BaseAgaveClient`

2. Improved `ProjectManagement` class:
   - Added decorators for input validation (`ensure_account_token`, `ensure_project_id`)
   - Refactored API calls into a single `_api_call` method
   - Simplified individual resource methods

3. Enhanced error handling and type hinting

4. Added new method: `drawing_versions`

5. Implemented tests for project management endpoints:
   - Added `tests/project_management.py` with functions to test all API endpoints
   - Includes data saving functionality for test results
